### PR TITLE
Ambapo endpoint for UTM to LatLng conversion

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -57,6 +57,11 @@
             </exclusions>
         </dependency>
         <dependency>
+	    <groupId>com.github.CIRDLES.Ambapo</groupId>
+	    <artifactId>core</artifactId>
+	    <version>0.10</version>
+	</dependency>
+        <dependency>
             <groupId>javax.servlet</groupId>
             <artifactId>javax.servlet-api</artifactId>
             <version>3.1.0</version>
@@ -72,6 +77,11 @@
             <groupId>org.springframework</groupId>
             <artifactId>spring-web</artifactId>
             <version>3.0.4.RELEASE</version>
+        </dependency>
+        <dependency>
+            <groupId>org.json</groupId>
+            <artifactId>json</artifactId>
+            <version>20180130</version>
         </dependency>
     </dependencies>
 

--- a/src/main/java/org/cirdles/webServices/ambapo/AmbapoServlet.java
+++ b/src/main/java/org/cirdles/webServices/ambapo/AmbapoServlet.java
@@ -6,32 +6,22 @@
 package org.cirdles.webServices.ambapo;
 
 import java.io.IOException;
-import java.io.PrintWriter;
+import java.math.BigDecimal;
 import javax.servlet.ServletException;
 import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
+import javax.servlet.http.HttpSession;
+import org.springframework.web.bind.ServletRequestUtils;
+import org.cirdles.webServices.requestUtils.*;
+import org.cirdles.ambapo.*;
+import org.json.JSONObject;
 
 /**
  *
  * @author ty
  */
 public class AmbapoServlet extends HttpServlet {
-
-    /**
-     * Processes requests for both HTTP <code>GET</code> and <code>POST</code>
-     * methods.
-     *
-     * @param request servlet request
-     * @param response servlet response
-     * @throws ServletException if a servlet-specific error occurs
-     * @throws IOException if an I/O error occurs
-     */
-    protected void processRequest(HttpServletRequest request, HttpServletResponse response)
-            throws ServletException, IOException {
-        response.setContentType("text/html;charset=UTF-8");
-        
-    }
 
     // <editor-fold defaultstate="collapsed" desc="HttpServlet methods. Click on the + sign on the left to edit the code.">
     /**
@@ -45,7 +35,7 @@ public class AmbapoServlet extends HttpServlet {
     @Override
     protected void doGet(HttpServletRequest request, HttpServletResponse response)
             throws ServletException, IOException {
-        processRequest(request, response);
+        
     }
 
     /**
@@ -59,9 +49,46 @@ public class AmbapoServlet extends HttpServlet {
     @Override
     protected void doPost(HttpServletRequest request, HttpServletResponse response)
             throws ServletException, IOException {
-        processRequest(request, response);
+        String uri = request.getRequestURI().toLowerCase();
+        String[] pieces = uri.split("/");
+        // first item will be "", second item will be "ambapo"
+        if (pieces.length >= 4) {
+            // UTM -> LatLng
+            if (pieces[2].equals("utm") && pieces[3].equals("latlng")) {
+                JSONObject json = RequestJSONUtils.extractRequestJSON(request);
+                BigDecimal easting = BigDecimal.valueOf(json.getLong("easting"));
+                BigDecimal northing = BigDecimal.valueOf(json.getLong("northing"));
+                String hemStr = json.getString("hemisphere");
+                int zoneNumber = json.getInt("zoneNumber");
+                String zoneStr = json.getString("zoneLetter");
+                String datum = json.getString("datum");
+                if (easting != null && northing != null &&
+                        hemStr != null && !hemStr.isEmpty() &&
+                        zoneStr != null && !zoneStr.isEmpty() &&
+                        datum != null && !datum.isEmpty()) {
+                    char hemisphere = hemStr.charAt(0);
+                    char zoneLetter = zoneStr.charAt(0);
+                    try {
+                        UTM utm = new UTM(easting, northing, hemisphere, zoneNumber, zoneLetter);
+                        Coordinate coord = UTMToLatLong.convert(utm, datum);
+                        JSONObject responseJson = new JSONObject();
+                        responseJson.put("latitude", coord.getLatitude());
+                        responseJson.put("longitude", coord.getLongitude());
+                        responseJson.put("datum", coord.getDatum());
+                        response.setContentType("application/json");
+                        response.getWriter().println(responseJson);
+                    } catch (Exception e) {
+                        // TODO: what to send as response?
+                        response.sendError(491);
+                    }
+                } else {
+                    // TODO: what to send as response?
+                    response.sendError(490);
+                }
+            }
+        }
     }
-
+    
     /**
      * Returns a short description of the servlet.
      *
@@ -69,7 +96,7 @@ public class AmbapoServlet extends HttpServlet {
      */
     @Override
     public String getServletInfo() {
-        return "Short description";
+        return "Ambapo Servlet";
     }// </editor-fold>
 
 }

--- a/src/main/java/org/cirdles/webServices/calamari/CalamariServlet.java
+++ b/src/main/java/org/cirdles/webServices/calamari/CalamariServlet.java
@@ -15,6 +15,7 @@ import javax.servlet.annotation.MultipartConfig;
 import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
+import javax.servlet.http.HttpSession;
 import javax.servlet.http.Part;
 import org.apache.commons.io.FilenameUtils;
 import org.apache.commons.io.IOUtils;
@@ -67,6 +68,8 @@ public class CalamariServlet extends HttpServlet {
     @Override
     protected void doPost(HttpServletRequest request, HttpServletResponse response)
             throws ServletException, IOException {
+        
+        HttpSession session = request.getSession();
 
         response.setContentType("application/zip");
         response.setHeader("Content-Disposition", "attachment; filename=calamari-reports.zip");
@@ -85,12 +88,10 @@ public class CalamariServlet extends HttpServlet {
         
         try {
             File report = null;
-            if(fileExt.equals("zip"))
-            {
+            if(fileExt.equals("zip")) {
                 report = handler.generateReportsZip(fileName, fileStream, useSBM, useLinFits, firstLetterRM).toFile();
             }
-            else if(fileExt.equals("xml"))
-            {
+            else if(fileExt.equals("xml")) {
                 report = handler.generateReports(fileName, fileStream, useSBM, useLinFits, firstLetterRM).toFile();
             }
 
@@ -110,7 +111,7 @@ public class CalamariServlet extends HttpServlet {
      */
     @Override
     public String getServletInfo() {
-        return "Short description";
+        return "Calamari Servlet";
     }// </editor-fold>
 
 }

--- a/src/main/java/org/cirdles/webServices/requestUtils/RequestJSONUtils.java
+++ b/src/main/java/org/cirdles/webServices/requestUtils/RequestJSONUtils.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2018 CIRDLES.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.cirdles.webServices.requestUtils;
+
+import java.io.IOException;
+import javax.servlet.http.HttpServletRequest;
+import org.json.JSONObject;
+
+/**
+ *
+ * @author ty
+ */
+public class RequestJSONUtils {
+    public static JSONObject extractRequestJSON(HttpServletRequest request) throws IOException {
+        String body = request.getReader().lines()
+                .reduce("", (accumulator, actual) -> accumulator + actual);
+        return new JSONObject(body);
+    }
+}

--- a/src/main/webapp/WEB-INF/web.xml
+++ b/src/main/webapp/WEB-INF/web.xml
@@ -14,7 +14,7 @@
     </servlet-mapping>
     <servlet-mapping>
         <servlet-name>AmbapoServlet</servlet-name>
-        <url-pattern>/ambapo</url-pattern>
+        <url-pattern>/ambapo/*</url-pattern>
     </servlet-mapping>
     <session-config>
         <session-timeout>


### PR DESCRIPTION
The /ambapo/utm/latlng endpoint now accepts a JSON object containing UTM data and sends back another JSON object containing the converted LatLng data.

A request should look similar to the following:
{
	"easting": 599541,
	"northing": 3627823,
	"hemisphere": "n",
	"zoneNumber": 17,
	"zoneLetter": "S",
	"datum": "WGS84"
}